### PR TITLE
Make setup.py happy and ignore some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+*.pyc


### PR DESCRIPTION
Running setup.py or using the url for this repo in pip install will bail because the test directory is missing. This simple patch adds the directory to the repo. Tested by putting this into my requirements.txt:

git+https://github.com/kewisch/python-crucible@pip-setup#egg=python-crucible

(which will later work if you use git+https://github.com/marook/python-crucible#egg=python-crucible)